### PR TITLE
Massively simplify the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ My current suggested workflow is to include a call to `process-ns!` at the botto
 
 ## Kaocha
 
-You'll may need to tweak your kaocha configuration so it will run tests in namespaces that don't end with `-test`, make sure it's set to `".*"`.
+You may need to tweak your kaocha configuration so it will run tests in namespaces that don't end with `-test`, make sure it's set to `".*"`.
 
 ```clojure
 {:kaocha/tests

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 >
 > &mdash; <cite>[Cambridge English Dictionary][dict-def]</cite>
 
-Exemplary will export examples that you write for your functions into the function doc string. It will also create tests in the matching `-test` suffixed namespace that can be executed by your test runner. Test runners like [kaocha][] can automatically re-run these example based tests as you make changes.
+Exemplary will export examples that you write for your functions into the function doc string. It will also create tests attached to the vars that can be executed by your test runner. Test runners like [kaocha][] can automatically re-run these example based tests as you make changes.
 
 ## Usage
 
@@ -58,6 +58,17 @@ thing.doer/half
 We use markdown in order to format the code nicely in [cljdoc][]. We now also have some new tests defined in `thing.doer-test` that will be picked up and executed by our test runner.
 
 My current suggested workflow is to include a call to `process-ns!` at the bottom of your files that use this library. This is reloaded when you load the file in your REPL or when [kaocha][] detects changes and reloads the file.
+
+## Kaocha
+
+You'll may need to tweak your kaocha configuration so it will run tests in namespaces that don't end with `-test`, make sure it's set to `".*"`.
+
+```clojure
+{:kaocha/tests
+ [{:kaocha/ns-patterns [".*"]}]}
+```
+
+## Feedback
 
 This library is still very new and I'd love to hear your thoughts on how we could improve this UX, maybe something like how [malli][]'s [dev instrumentation][malli-dev-inst] works? Please feel free to reach out to me on [mastodon][] or open a discussion here about the topic.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 >
 > &mdash; <cite>[Cambridge English Dictionary][dict-def]</cite>
 
-Exemplary will export examples that you write for your functions into the function doc string. It will also create tests attached to the vars that can be executed by your test runner. Test runners like [kaocha][] can automatically re-run these example based tests as you make changes.
+Exemplary translates examples into function documentation and runnable tests. Test runners like [kaocha][] can automatically re-run these example based tests as you make changes while [cljdoc][] will display your examples with proper Clojure syntax highlighting.
 
 ## Usage
 
@@ -58,17 +58,15 @@ thing.doer/half
 ```
 ````
 
-We use markdown in order to format the code nicely in [cljdoc][]. We now also have some new tests defined in `thing.doer-test` that will be picked up and executed by our test runner.
-
 ## Instrumentation
 
 You can either add `(ex/process-ns!)` to the bottom of the namespaces you wish to instrument or add a call to `(ex/process-all-ns! #"^my-project\.")` somewhere at the root of your system. This way you can have one instrumentation call that will find all of the examples for you automatically.
 
-You'll need to make sure this is re-executed when you make changes if you want the examples to be updated in your current REPL. Running it once should be enough for your test suite or cljdoc output though.
+You will need to make sure this is re-executed when you make changes if you want the examples to be updated in your running REPL. Executing it once should be enough for your test suite or [cljdoc][] output.
 
 ## Kaocha
 
-You may need to tweak your kaocha configuration so it will run tests in namespaces that don't end with `-test`, make sure it's set to `".*"`.
+You may need to tweak your [kaocha][] configuration so it will run tests in namespaces that don't end with `-test`, make sure it's set to `".*"`.
 
 ```clojure
 {:kaocha/tests
@@ -77,7 +75,7 @@ You may need to tweak your kaocha configuration so it will run tests in namespac
 
 ## Feedback
 
-This library is still very new and I'd love to hear your thoughts on how we could improve this UX, maybe something like how [malli][]'s [dev instrumentation][malli-dev-inst] works? Please feel free to reach out to me on [mastodon][] or open a discussion here about the topic.
+I'd love to hear your thoughts, please feel free to reach out to me on [mastodon][] or open a discussion on this repository.
 
 [dict-def]: https://dictionary.cambridge.org/dictionary/english/exemplary
 [kaocha]: https://github.com/lambdaisland/kaocha

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Exemplary will export examples that you write for your functions into the functi
   (/ n 2))
 
 (ex/process-ns!)
+
+;; Alternatively...
+; (ex/process-all-ns! #"^thing\.")
 ```
 
 The docstrings for these functions will now look like this:
@@ -57,7 +60,11 @@ thing.doer/half
 
 We use markdown in order to format the code nicely in [cljdoc][]. We now also have some new tests defined in `thing.doer-test` that will be picked up and executed by our test runner.
 
-My current suggested workflow is to include a call to `process-ns!` at the bottom of your files that use this library. This is reloaded when you load the file in your REPL or when [kaocha][] detects changes and reloads the file.
+## Instrumentation
+
+You can either add `(ex/process-ns!)` to the bottom of the namespaces you wish to instrument or add a call to `(ex/process-all-ns! #"^my-project\.")` somewhere at the root of your system. This way you can have one instrumentation call that will find all of the examples for you automatically.
+
+You'll need to make sure this is re-executed when you make changes if you want the examples to be updated in your current REPL. Running it once should be enough for your test suite or cljdoc output though.
 
 ## Kaocha
 

--- a/src/exemplary/core.clj
+++ b/src/exemplary/core.clj
@@ -1,35 +1,11 @@
 (ns exemplary.core
-  (:require [clojure.string :as str]))
-
-(defn ^:no-doc var->test-name-symbol
-  "Takes a var and returns a simple-symbol to be used in a deftest name."
-  {::example '(= 'var->test-name-symbol-exemplary-test
-                 (var->test-name-symbol #'var->test-name-symbol))}
-  [var]
-  (symbol (str (:name (meta var)) "-exemplary-test")))
-
-(defn ^:no-doc test-ns?
-  "Given a namespace, returns true if it ends in -test."
-  [ns]
-  (str/ends-with? (str ns) "-test"))
-
-(defn ^:no-doc ns->test-ns
-  "Given a namespace, returns the -test suffixed version of the same namespace."
-  [ns]
-  (create-ns (symbol (str ns "-test"))))
-
-(defn ^:no-doc move-var
-  "Moves a var from one ns to another. Also copies all metadata over to the new var but without the :ns key which will be different now."
-  [from-ns to-ns var-name]
-  (let [var (ns-resolve from-ns var-name)]
-    (intern to-ns var-name (var-get var))
-    (ns-unmap from-ns var-name)
-    (let [moved-var (ns-resolve to-ns var-name)]
-      (alter-meta! moved-var merge (dissoc (meta var) :ns))
-      moved-var)))
+  (:require [clojure.string :as str]
+            [clojure.test :as t]))
 
 (defn process-var!
-  "The vars examples will be added to the docstring and clojure.test/deftest calls will be created for you within the current namespace. You can use :exemplary.core/examples with a list/vector of examples or :exemplary.core/example with a single example.
+  "The vars examples will be added to the docstring and the var will become executable by clojure.test. You can use :exemplary.core/examples with a list/vector of examples or :exemplary.core/example with a single example.
+
+  When clojure.test/*load-tests* is false the test metadata will be omitted, only the doc string will be updated.
 
   You must quote your code to ensure it doesn't execute immidiately. So you will have something like one of these in your function params which come after the doc string:
 
@@ -53,40 +29,33 @@
   (assert (var? var) (str "var required, got " (type var)))
 
   (let [meta (meta var)
+        original-ns (:ns meta)
         examples (or (seq (::examples meta))
                      (and (::example meta) [(::example meta)]))]
     (when examples
       (alter-meta!
        var
        (fn [meta]
-         (let [meta (dissoc meta ::examples ::example)]
-           (update
-            meta :doc
-            (fn [original]
-              (str
-               original
-               (when-not (empty? original)
-                 "\n\n")
-               "```clojure\n"
-               (str/join "\n" (map pr-str examples))
-               "\n```"))))))
-
-      (require 'clojure.test)
-      (let [original-ns (:ns meta)
-            test-var-name (var->test-name-symbol var)
-            test-var
-            (binding [*ns* original-ns]
-              (eval
-               `(clojure.test/deftest
-                  ^:exemplary.core/test
-                  ~test-var-name
-                  ~@(map
+         (-> (dissoc meta ::examples ::example)
+             (update
+              :doc
+              (fn [original]
+                (str
+                 original
+                 (when-not (empty? original)
+                   "\n\n")
+                 "```clojure\n"
+                 (str/join "\n" (map pr-str examples))
+                 "\n```")))
+             (cond-> t/*load-tests*
+               (assoc
+                :test
+                (fn []
+                  (binding [*ns* original-ns]
+                    (run!
                      (fn [example]
-                       `(clojure.test/is ~example))
-                     examples))))]
-        (if (test-ns? original-ns)
-          test-var
-          (move-var original-ns (ns->test-ns original-ns) test-var-name))))))
+                       (t/is (eval example)))
+                     examples)))))))))))
 
 (defn process-ns!
   "Runs all vars in a ns through process-var! When given no arguments it will process the current ns."

--- a/src/exemplary/core.clj
+++ b/src/exemplary/core.clj
@@ -65,4 +65,9 @@
      (when (var? var)
        (process-var! var)))))
 
-(process-ns!)
+(defn process-all-ns!
+  "Process all loaded namespaces where their name matches the regular expression."
+  [re]
+  (doseq [ns (all-ns)]
+    (when (re-find re (str ns))
+      (process-ns! ns))))

--- a/test/exemplary/core_test.clj
+++ b/test/exemplary/core_test.clj
@@ -47,3 +47,15 @@
       (exemplary/process-ns! 'exemplary.core-test)
       (t/is (spy/called-with? exemplary/process-var! #'exemplary.core-test/square))
       (t/is (spy/called-with? exemplary/process-var! #'exemplary.core-test/half)))))
+
+(t/deftest process-all-ns!
+  (t/testing "calls process-var! on every var in every ns that matches the pattern"
+    (with-redefs [exemplary/process-var! (spy/spy)]
+      (exemplary/process-all-ns! #"^exemplary\.")
+      (t/is (spy/called-with? exemplary/process-var! #'exemplary.core-test/square))
+      (t/is (spy/called-with? exemplary/process-var! #'exemplary.core-test/half))))
+
+  (t/testing "doesn't call process-var! if the pattern doesn't match anything"
+    (with-redefs [exemplary/process-var! (spy/spy)]
+      (exemplary/process-all-ns! #"^something-that-doesnt-exist\.")
+      (t/is (spy/not-called? exemplary/process-var!)))))

--- a/test/exemplary/core_test.clj
+++ b/test/exemplary/core_test.clj
@@ -18,19 +18,12 @@
   [n]
   (/ n 2))
 
-(t/deftest var->test-name-symbol
-  (t/testing "adds the correct suffix to a vars name and returns it as a symbol"
-    (t/is (= 'square-exemplary-test (exemplary/var->test-name-symbol #'square)))))
-
 (defn test-var-fixture
   "Instrument the test fns for use in meta testing."
   [f]
-  (alter-meta! (intern 'exemplary.core-test 'example-var 42) merge {:foo true})
   (exemplary/process-var! #'square)
   (exemplary/process-var! #'half)
-  (f)
-  (create-ns 'exemplary.made-up-namespace)
-  (ns-unmap 'exemplary.made-up-namespace 'example-var))
+  (f))
 
 (t/use-fixtures :once test-var-fixture)
 
@@ -42,41 +35,11 @@
     (t/is (= "It halves numbers.\n\n```clojure\n(= 5 (half 10))\n```"
              (:doc (meta #'half)))))
 
-  (t/testing "creates test vars under known names"
-    (t/is (var? (resolve 'exemplary.core-test/square-exemplary-test)))
-    (t/is (var? (resolve 'exemplary.core-test/half-exemplary-test))))
-
-  (t/testing "we can execute these tests and check the function"
+  (t/testing "we can execute the vars as tests"
     (t/is (= {:test 1, :pass 2, :fail 0, :error 0, :type :summary}
-             (t/run-test-var (resolve 'exemplary.core-test/square-exemplary-test))))
+             (t/run-test-var (resolve 'exemplary.core-test/square))))
     (t/is (= {:test 1, :pass 1, :fail 0, :error 0, :type :summary}
-             (t/run-test-var (resolve 'exemplary.core-test/half-exemplary-test))))))
-
-(t/deftest test-ns?
-  (t/testing "returns true for test namespaces"
-    (t/is (not (exemplary/test-ns? 'exemplary.core)))
-    (t/is (exemplary/test-ns? 'exemplary.core-test))))
-
-(t/deftest ns->test-ns
-  (t/testing "converts a namespace to a test namespace"
-    (t/is (= 'exemplary.core-test
-             (ns-name
-              (exemplary/ns->test-ns
-               (the-ns 'exemplary.core)))))))
-
-(t/deftest move-var
-  (t/testing "moves a var from one namespace to another and returns the new one, carries over metadata"
-    (t/is (nil? (resolve 'exemplary.made-up-namespace/example-var)))
-    (exemplary/move-var
-     (the-ns 'exemplary.core-test)
-     (create-ns 'exemplary.made-up-namespace)
-     'example-var)
-    (let [var (resolve 'exemplary.made-up-namespace/example-var)]
-      (t/is (= 42 (var-get var)))
-      (t/is (= {:foo true
-                :name 'example-var
-                :ns (the-ns 'exemplary.made-up-namespace)}
-               (meta var))))))
+             (t/run-test-var (resolve 'exemplary.core-test/half))))))
 
 (t/deftest process-ns!
   (t/testing "calls process-var! on every var in an ns"

--- a/tests.edn
+++ b/tests.edn
@@ -1,7 +1,7 @@
 {:kaocha/tests
  [{:kaocha.testable/type :kaocha.type/clojure.test,
    :kaocha.testable/id :unit,
-   :kaocha/ns-patterns ["-test$"],
+   :kaocha/ns-patterns [".*"],
    :kaocha/source-paths ["src"],
    :kaocha/test-paths ["test"],
    :kaocha.filter/skip-meta [:kaocha/skip]}],


### PR DESCRIPTION
Fixes #4, no more namespace tomfoolery, we just modify the var and add a `:test` function if `clojure.test/*load-tests*` is true, which is also what `clojure.test/deftest` checks.

So now we need far less code to get the same result essentially. Have to tell kaocha to run tests in any namespace though, the filter would prevent tests in source files from running which is a gotcha.